### PR TITLE
Detect maximum version in subdirectories

### DIFF
--- a/lib/activerecord/quiet_schema_version/schema.rb
+++ b/lib/activerecord/quiet_schema_version/schema.rb
@@ -15,7 +15,7 @@ module Activerecord
 
         def detect_maximum_version
           migrations_paths = ActiveRecord::Migrator.migrations_paths
-          paths = migrations_paths.map { |p| "#{p}/[0-9]*_*.rb" }
+          paths = migrations_paths.map { |p| "#{p}/**/[0-9]*_*.rb" }
           versions = Dir[*paths].map do |filename|
             filename.split("/").last.split("_").first.to_i
           end


### PR DESCRIPTION
Because `db:migrate` detects migrations in subdirectories.
https://github.com/rails/rails/blob/v4.2.8/activerecord/lib/active_record/migration.rb#L886